### PR TITLE
fix: :bug: correctly save/load default config (prevent overriding of …

### DIFF
--- a/src/main/java/me/pandauprising/setspawn/SetSpawn.java
+++ b/src/main/java/me/pandauprising/setspawn/SetSpawn.java
@@ -8,6 +8,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
 import java.util.Objects;
 
 public final class SetSpawn extends JavaPlugin {
@@ -37,8 +38,16 @@ public final class SetSpawn extends JavaPlugin {
 
         //config.yml
         config = this.getConfig();
-        getConfig().options().copyDefaults();
-        saveDefaultConfig();
+
+        File configFile = new File(getDataFolder(), "config.yml");
+
+        if(!configFile.exists()) {
+            getConfig().options().copyDefaults();
+            saveDefaultConfig();
+            reloadConfig();
+        }
+
+        saveConfig();
 
         Objects.requireNonNull(getCommand("setspawn")).setExecutor(new SetSpawnCommand(this));
         Objects.requireNonNull(getCommand("spawn")).setExecutor(new SpawnCommand(this));


### PR DESCRIPTION
…default config)

This fix modifies the way how/when the default config is being created. This therefore no longer overrides the entire default config, with all its values, once the /setspawn command is executed.

(Regarding [this](https://github.com/PandaUprising/SetSpawn/issues/1#issuecomment-1875754240))

closed #1